### PR TITLE
DB-4921: CA DWR: implement download functionality

### DIFF
--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -288,7 +288,7 @@ class QueryView(FeatureLayerView):
                         x_loc, y_loc = str(item['st_astext']).replace('POINT(', '').replace(')', '').split(' ')
                         item['geometry_x_location'] = x_loc
                         item['geometry_y_location'] = y_loc
-                    data.append([str(item[field]).strip('"').join('""') for field in header])
+                    data.append([str(item[field]).replace('"', '""').strip('"').join('""') for field in header])
         else:
             data = {
                 'count': len(query_response),

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -244,14 +244,15 @@ class QueryView(FeatureLayerView):
         if kwargs.get('geometryType') == 'esriGeometryEnvelope':
             search_params['extent'] = Extent(json.loads(kwargs['geometry']))
 
-        if kwargs.get('outFields') and not return_ids_only:
+        if not return_ids_only and kwargs.get('outFields'):
             search_params['return_fields'] = (kwargs['outFields'] or '').split(',')
 
-        if kwargs.get('orderByFields') and not return_ids_only:
+        if not return_ids_only and kwargs.get('orderByFields'):
             search_params['order_by_fields'] = (kwargs['orderByFields'] or '').split(',')
 
         if return_format == 'csv':
             search_params['return_geometry'] = False
+            search_params['order_by_fields'] = search_params['return_fields']  # Enforce order for batched queries
         elif return_ids_only:
             search_params['return_fields'] = [self.feature_service_layer.object_id_field]
             search_params['return_geometry'] = False

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -212,12 +212,12 @@ class TimeQueryView(FeatureLayerView):
 
 
 class QueryView(FeatureLayerView):
-    query_limit_default = 1000
+    query_limit_default = 50000
 
     def handle_request(self, request, **kwargs):
 
         search_params = {}
-        limit, offset = kwargs.get('limit', self.query_limit_default), kwargs.get('offset', 0)
+        limit, offset = int(kwargs.get('limit', self.query_limit_default)), int(kwargs.get('offset', 0))
 
         # Capture format type: default anything but csv or json to json
         valid_formats = {'csv', 'json'}
@@ -252,7 +252,6 @@ class QueryView(FeatureLayerView):
 
         if return_format == 'csv':
             search_params['return_geometry'] = False
-            search_params['order_by_fields'] = search_params['return_fields']  # Enforce order for batched queries
         elif return_ids_only:
             search_params['return_fields'] = [self.feature_service_layer.object_id_field]
             search_params['return_geometry'] = False
@@ -427,7 +426,7 @@ def convert_wkt_to_esri_feature(response_items, for_layer):
                 fk, pk = info['source'], info['target']
                 to_add = to_be_related[table]
 
-                item_hash = item_hash_format.format(id=item['id'], fk=fk, val=to_add[pk], table=table)
+                item_hash = item_hash_format.format(id=item['db_id'], fk=fk, val=to_add[pk], table=table)
                 if item_hash in already_added:
                     removed = to_be_related.pop(table)
                     related = already_added[item_hash]['related']

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -274,8 +274,10 @@ class QueryView(FeatureLayerView):
         if return_count_only:
             data = query_response[0]
         elif return_format == 'csv':
-            header = query_response[0].keys()
-            data = [[h.strip('"').join('""') for h in header]]
+            header = list(query_response[0].keys())
+            header.sort()
+
+            data = [[h.strip('"').join('""') for h in header]] if offset == 0 else []
             for item in query_response:
                 data.append([str(item[field]).strip('"').join('""') for field in header])
         else:

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -217,7 +217,8 @@ class QueryView(FeatureLayerView):
     def handle_request(self, request, **kwargs):
 
         search_params = {}
-        limit, offset = int(kwargs.get('limit', self.query_limit_default)), int(kwargs.get('offset', 0))
+        limit = int(kwargs.get('limit', self.query_limit_default))
+        offset = int(kwargs.get('offset', 0))
 
         # Capture format type: default anything but csv or json to json
         valid_formats = {'csv', 'json'}

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -5,6 +5,7 @@ import re
 import uuid
 import sqlparse
 
+from collections import OrderedDict
 from datetime import datetime
 from django.conf import settings
 from django.db import models, DatabaseError, connection
@@ -60,7 +61,7 @@ def get_fields(for_table):
                 'SELECT column_name, is_nullable, data_type',
                 'FROM information_schema.columns',
                 'WHERE table_name = %s',
-                'ORDER BY column_name;'
+                'ORDER BY ordinal_position;'
             )),
             [for_table]
         )
@@ -211,7 +212,7 @@ class FeatureServiceLayer(models.Model):
     def related_fields(self):
         if self._related_fields is None:
 
-            self._related_fields = {}
+            self._related_fields = OrderedDict()
             for field in (f for r in self.relations for f in r.fields):
                 field_key = field['alias']  # Will be related_title.field
                 self.related_fields[field_key] = field

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from django.conf import settings
 from django.db import models, DatabaseError, connection
 from django.db.models import signals
+from django.utils.datastructures import OrderedSet
 from sqlparse.tokens import Token
 
 from tablo.utils import get_jenks_breaks, dictfetchall
@@ -55,7 +56,12 @@ def get_fields(for_table):
     fields = []
     with connection.cursor() as c:
         c.execute(
-            'select column_name, is_nullable, data_type from information_schema.columns where table_name = %s;',
+            ' '.join((
+                'SELECT column_name, is_nullable, data_type',
+                'FROM information_schema.columns',
+                'WHERE table_name = %s',
+                'ORDER BY column_name;'
+            )),
             [for_table]
         )
         # c.description won't be populated without first running the query above
@@ -184,6 +190,7 @@ class FeatureServiceLayer(models.Model):
     @property
     def fields(self):
         if self._fields is None:
+
             fields = get_fields(self.table)
             for field in fields:
                 if field['name'] == 'db_id':
@@ -203,11 +210,10 @@ class FeatureServiceLayer(models.Model):
     @property
     def related_fields(self):
         if self._related_fields is None:
-            fields_by_title = ((r.related_title, f) for r in self.relations for f in r.fields)
 
             self._related_fields = {}
-            for table, field in fields_by_title:
-                field_key = '{0}.{1}'.format(table, field['name'])
+            for field in (f for r in self.relations for f in r.fields):
+                field_key = field['alias']  # Will be related_title.field
                 self.related_fields[field_key] = field
 
         return self._related_fields
@@ -226,7 +232,7 @@ class FeatureServiceLayer(models.Model):
     def perform_query(self, limit=0, offset=0, **kwargs):
         count_only = kwargs.pop('count_only', False)
         ids_only = kwargs.pop('ids_only', False)
-        return_fields = kwargs.get('return_fields', ['*']) if not ids_only else [self.object_id_field]
+        return_fields = kwargs.get('return_fields', ['*'])
         return_geometry = kwargs.get('return_geometry', True)
         out_sr = kwargs.get('out_sr') or WEB_MERCATOR_SRID
 
@@ -238,32 +244,28 @@ class FeatureServiceLayer(models.Model):
         # These are the possible points of SQL injection. All other dynamically composed pieces of SQL are
         # constructed using items within the database, or are escaped using the database engine.
 
-        valid_select_fields = self._validate_fields(return_fields)
+        valid_select_fields = ids_only or self._validate_fields(return_fields)
         valid_where_clause = self._validate_where_clause(additional_where_clause)
-        valid_order_by_fields = self._validate_fields(order_by_fields)
+        valid_order_by_fields = ids_only or self._validate_fields(order_by_fields)
 
         if not (valid_select_fields and valid_where_clause and valid_order_by_fields):
             raise ValueError('Invalid query parameters')
 
-        expanded_fields = self._expand_return_fields(return_fields)
-
         if count_only:
             select_fields = 'COUNT(0)'
         elif ids_only:
+            return_fields = order_by_fields = [self.object_id_field]
             select_fields = 'DISTINCT {0}'.format(self._alias_fields(return_fields))
-            order_by_fields = [return_fields]  # Order by can only be used on return_fields with distinct
         else:
-            select_fields = '{select}'.format(select=', '.join(expanded_fields))
+            select_fields = self._expand_fields(return_fields)
             if return_geometry:
                 select_fields += ', ST_AsText(ST_Transform("source"."dbasin_geom", {0}))'.format(out_sr)
 
         join, related_tables = self._build_join_clause(return_fields, additional_where_clause)
         where, query_params = self._build_where_clause(additional_where_clause, count_only, **kwargs)
-        if not count_only:
-            if ids_only:
-                order_by = self._build_order_by_clause([self.object_id_field])
-            else:
-                order_by = self._build_order_by_clause(order_by_fields, related_tables)
+        order_by = '' if count_only else self._build_order_by_clause(
+            fields=order_by_fields, related_tables=(None if ids_only else related_tables)
+        )
 
         with get_cursor() as c:
             query_clause = 'SELECT {fields} FROM "{table}" AS "source" {join} {where} {order_by} {limit_offset}'
@@ -281,31 +283,35 @@ class FeatureServiceLayer(models.Model):
 
         if not fields:
             return '"source".*'
+        elif isinstance(fields, str):
+            fields = [fields]
 
         aliased_fields = [f if '.' in f else 'source.{0}'.format(f) for f in fields]
         quoted_fields = '", "'.join('"."'.join(f.split('.')) for f in aliased_fields).join('""')
 
         return quoted_fields.replace('"*"', '*')
 
-    def _expand_return_fields(self, return_fields):
-        related_return_fields = [r for r in return_fields if '.' in r]
+    def _expand_fields(self, fields, alias_only=False):
+        """ Expand '*' in fields to those that will be queried, and optionally alias them to avoid clashes """
 
-        if not related_return_fields:
-            return [self._alias_fields([r]) for r in return_fields]
+        if not any('.' in f for f in fields):
+            return self._alias_fields(fields)
 
-        expanded_fields = []
-        for return_field in return_fields:
-            if return_field == '*':
-                for f in self.fields:
-                    expanded_fields.append('{0} AS "{1}"'.format(self._alias_fields([f['name']]), f['name']))
-            elif return_field.endswith('.*'):
-                relationship_name = return_field[:-2]
-                for r in (x for x in self.related_fields if x.startswith(relationship_name + '.')):
-                    expanded_fields.append('{0} AS "{1}"'.format(self._alias_fields([r]), r))
+        fields_to_expand = [self.object_id_field]
+        fields_to_expand.extend(r.source_column for r in self.relations)
+
+        for field in fields:
+            if field == '*':
+                fields_to_expand.extend(f['name'] for f in self.fields)
+            elif field.endswith('.*'):
+                related_prefix = field[:-1]
+                fields_to_expand.extend(f for f in self.related_fields if f.startswith(related_prefix))
             else:
-                expanded_fields.append('{0} AS "{1}"'.format(self._alias_fields([return_field]), return_field))
+                fields_to_expand.append(field)
 
-        return expanded_fields
+        field_format = '"{1}"' if alias_only else '{0} AS "{1}"'
+
+        return ', '.join(field_format.format(self._alias_fields(f), f) for f in OrderedSet(fields_to_expand))
 
     def _build_join_clause(self, fields, where, **kwargs):
         if not fields and where is None:
@@ -409,7 +415,7 @@ class FeatureServiceLayer(models.Model):
             for relation in self.relations.filter(related_title__in=related_tables).order_by('-related_index'):
                 insert_field(order_by_fields, relation.source_column, 0)  # Ensure ordering by source table keys
 
-        return order_by_clause.format(fields=self._alias_fields(order_by_fields))
+        return order_by_clause.format(fields=self._expand_fields(order_by_fields, alias_only=True))
 
     def _parse_where_clause(self, where):
         if where is None:
@@ -715,7 +721,12 @@ class FeatureServiceLayerRelations(models.Model):
     @property
     def fields(self):
         if self._fields is None:
-            self._fields = get_fields(self.table)
+
+            fields = get_fields(self.table)
+            for field in fields:
+                field['alias'] = '{0}.{1}'.format(self.related_title, field['name'])
+            self._fields = fields
+
         return self._fields
 
     @property

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -245,7 +245,7 @@ class FeatureServiceLayer(models.Model):
         if count_only:
             select_fields = 'COUNT(0)'
         else:
-            select_fields = '"source"."{pk}" AS "id", {select}'.format(
+            select_fields = '"source"."{pk}", {select}'.format(
                 pk=PRIMARY_KEY_NAME, select=self._alias_fields(return_fields)
             )
             if return_geometry:

--- a/tablo/tests/models_test.py
+++ b/tablo/tests/models_test.py
@@ -1,0 +1,210 @@
+from collections import OrderedDict
+
+from django.test import TestCase
+from tablo.models import FeatureService, FeatureServiceLayer, FeatureServiceLayerRelations
+from unittest.mock import patch, PropertyMock
+
+
+TABLE_NAME = 'db_table'
+
+
+class PerformQueryTestCase(TestCase):
+
+    def setUp(self):
+        feature_service = FeatureService.objects.create(description='FeatureServiceTestOne')
+        self.feature_service_layer = FeatureServiceLayer.objects.create(
+            service=feature_service,
+            layer_order=0,
+            table=TABLE_NAME,
+            name='FeatureServiceLayerTestOne',
+            object_id_field='db_id'
+        )
+
+        self.relationship = FeatureServiceLayerRelations.objects.create(
+            layer=self.feature_service_layer,
+            related_index=0,
+            related_title='measurements',
+            source_column='base_table_field',
+            target_column='base_table_field_ref'
+        )
+
+        feature_service2 = FeatureService.objects.create(description='FeatureServiceTestTwo')
+        self.feature_service_layer2 = FeatureServiceLayer.objects.create(
+            service=feature_service2,
+            layer_order=0,
+            table=TABLE_NAME,
+            name='FeatureServiceLayerTestTwo',
+            object_id_field='db_id'
+        )
+
+        self.relationship2 = FeatureServiceLayerRelations.objects.create(
+            layer=self.feature_service_layer2,
+            related_index=0,
+            related_title='measurements',
+            source_column='casgem_station_id',
+            target_column='casgem_station_id'
+        )
+
+    def test_no_where_clause(self):
+        self.validate_perform_query_sql(
+            {},
+            ('SELECT "source".*, ST_AsText(ST_Transform("source"."dbasin_geom", 3857)) '
+             'FROM "{table}" AS "source"  WHERE 1=1 ORDER BY "source".* LIMIT 0 OFFSET 0').format(
+                table=TABLE_NAME
+            )
+        )
+
+    def test_additional_where_clause(self):
+        # Mock out the fields for the table
+        with patch('tablo.models.FeatureServiceLayer.fields', new_callable=PropertyMock) as fields:
+            fields.return_value = ([{
+                'name': 'TEST',
+                'alias': 'TEST',
+                'type': 'esriFieldTypeInteger',
+                'nullable': True,
+                'editable': True
+            }])
+            self.validate_perform_query_sql(
+                {'additional_where_clause': 'TEST=1'},
+                ('SELECT "source".*, ST_AsText(ST_Transform("source"."dbasin_geom", 3857)) '
+                 'FROM "{table}" AS "source"  WHERE "source"."TEST"=1 '
+                 'ORDER BY "source".* LIMIT 0 OFFSET 0').format(
+                    table=TABLE_NAME
+                )
+            )
+
+    def test_related_query(self):
+        with patch('tablo.models.FeatureServiceLayer.fields', new_callable=PropertyMock) as fields:
+            with patch('tablo.models.FeatureServiceLayer.related_fields', new_callable=PropertyMock) as related_fields:
+                fields.return_value = ([{
+                    'name': 'base_table_field',
+                    'alias': 'base_table_field',
+                    'type': 'esriFieldTypeInteger',
+                    'nullable': True,
+                    'editable': True
+                }])
+
+                related_fields.return_value = {
+                    'measurements.base_table_field_ref': {
+                        'name': 'base_table_field_ref',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                    'measurements.well_depth': {
+                        'name': 'well_depth',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                }
+
+                self.validate_perform_query_sql(
+                    {'additional_where_clause': '("measurements.well_depth" > 50)'},
+                    ('SELECT "source".*, ST_AsText(ST_Transform("source"."dbasin_geom", 3857)) '
+                     'FROM "{table}" AS "source" LEFT OUTER JOIN "{table}_0" AS "measurements" '
+                     'ON "source"."base_table_field" = "measurements"."base_table_field_ref" '
+                     'WHERE ("measurements"."well_depth" > 50) '
+                     'ORDER BY "source"."base_table_field" LIMIT 0 OFFSET 0').format(
+                        table=TABLE_NAME
+                    )
+                )
+
+    def test_related_count(self):
+        with patch('tablo.models.FeatureServiceLayer.fields', new_callable=PropertyMock) as fields:
+            with patch('tablo.models.FeatureServiceLayer.related_fields', new_callable=PropertyMock) as related_fields:
+                fields.return_value = ([
+                    {
+                        'name': 'db_id'
+                    },
+                    {
+                        'name': 'base_table_field',
+                        'alias': 'base_table_field',
+                        'type': 'esriFieldTypeInteger',
+                        'nullable': True,
+                        'editable': True
+                    }
+                ])
+
+                related_fields.return_value = {
+                    'measurements.base_table_field_ref': {
+                        'name': 'base_table_field_ref',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                    'measurements.well_depth': {
+                        'name': 'well_depth',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                }
+
+                self.validate_perform_query_sql(
+                    {
+                        'additional_where_clause': '("measurements.well_depth" > 50)',
+                        'ids_only': True,
+                        'return_geometry': False
+                    },
+                    ('SELECT DISTINCT "source"."{object_id_field}" '
+                     'FROM "{table}" AS "source" LEFT OUTER JOIN "{table}_0" AS "measurements" '
+                     'ON "source"."base_table_field" = "measurements"."base_table_field_ref" '
+                     'WHERE ("measurements"."well_depth" > 50) '
+                     'ORDER BY "source"."{object_id_field}" LIMIT 0 OFFSET 0').format(
+                        table=TABLE_NAME,
+                        object_id_field=self.feature_service_layer.object_id_field
+                    )
+                )
+
+    def test_duplicate_field(self):
+        with patch('tablo.models.FeatureServiceLayer.fields', new_callable=PropertyMock) as fields:
+            with patch('tablo.models.FeatureServiceLayer.related_fields', new_callable=PropertyMock) as related_fields:
+                fields.return_value = ([
+                    {
+                        'name': 'db_id'
+                    },
+                    {
+                        'name': 'casgem_station_id',
+                        'alias': 'casgem_station_id',
+                        'type': 'esriFieldTypeInteger',
+                        'nullable': True,
+                        'editable': True
+                    }
+                ])
+
+                related_fields.return_value = OrderedDict({
+                    'measurements.casgem_station_id': {
+                        'name': 'casgem_station_id',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                    'measurements.something_else': {
+                        'name': 'something_else',
+                        'type': 'esriFieldTypeInteger'
+                    },
+                })
+
+                self.validate_perform_query_sql(
+                    {
+                        'return_fields': ['*', 'measurements.*'],
+                    },
+                    ('SELECT "source"."db_id" AS "db_id", "source"."casgem_station_id" AS "casgem_station_id", '
+                     '"measurements"."casgem_station_id" AS "measurements.casgem_station_id", '
+                     '"measurements"."something_else" AS "measurements.something_else", '
+                     'ST_AsText(ST_Transform("source"."dbasin_geom", 3857)) '
+                     'FROM "{table}" AS "source" LEFT OUTER JOIN "{table}_0" AS "measurements" '
+                     'ON "source"."casgem_station_id" = "measurements"."casgem_station_id" '
+                     'WHERE 1=1 '
+                     'ORDER BY "source"."casgem_station_id" LIMIT 0 OFFSET 0').format(
+                        table=TABLE_NAME,
+                        object_id_field=self.feature_service_layer2.object_id_field
+                    ),
+                    layer=self.feature_service_layer2
+                )
+
+    def validate_perform_query_sql(self, perform_query_args, expected_sql, expected_sql_args=None, layer=None):
+        """
+        This method test the FeatureServiceLayer.perform_query given.
+
+        :param perform_query_args: The arguments that will be passed into the perform_query method. This should
+          be a dict, that will be passed in as the methods kwargs.
+        :param expected_sql: The SQL that is expected to be executed when the perform_query method is called.
+        :param expected_sql_args: The expected arguments to be passed into the SQL as parameters.
+        """
+        layer = layer or self.feature_service_layer
+        expected_sql_args = [] if expected_sql_args is None else expected_sql_args
+        with patch('tablo.models.connection') as mockconnection:
+            layer.perform_query(**perform_query_args)
+            mockconnection.cursor().__enter__().execute.assert_called_with(expected_sql, expected_sql_args)

--- a/tablo/utils.py
+++ b/tablo/utils.py
@@ -1,4 +1,6 @@
 import json
+from collections import OrderedDict
+
 from tastypie.fields import CharField
 
 
@@ -94,7 +96,7 @@ def dictfetchall(cursor):
     "Returns all rows from a cursor as a dict"
     desc = cursor.description
     return [
-        dict(zip([col[0] for col in desc], row))
+        OrderedDict(zip([col[0] for col in desc], row))
         for row in cursor.fetchall()
     ]
 

--- a/tablo/utils.py
+++ b/tablo/utils.py
@@ -53,8 +53,8 @@ def get_jenks_breaks(data_list, num_classes):
     kclass[num_classes] = float(data_list[len(data_list) - 1])
     count_num = num_classes
     while count_num >= 2:
-        id = int((mat1[k][count_num]) - 2)
-        kclass[count_num - 1] = data_list[id]
+        pk = int((mat1[k][count_num]) - 2)
+        kclass[count_num - 1] = data_list[pk]
         k = int((mat1[k][count_num] - 1))
         count_num -= 1
     return kclass


### PR DESCRIPTION
I don't mind saying this was comparatively easy. Here are some of the components of this task:

1. Add support for `f=csv` to `QueryView`
2. Validate `f` is either `csv` or `json`, and if not, force it to `json` (essentially ignore it)
3. Prevent id-only or count-only queries when `f=csv`
4. Prevent geometry in the returned fields when `f=csv`
5. Force ordering of records for all csv queries: order by the out fields
6. Omit header when `offset` is not zero (helps with batching)
7. Sort column headers for all csv queries to ensure same order per query (helps with batching)
8. Return content type `text/csv` and file with name `query.csv`

I think that accounts for the things that could go wrong, and ensures that a single batch query will always be the same as a series of appended queries. I tested this by comparing the output of three queries (ensures station data is split; only limit and offset differ per query):

1. ?where=casgem_station_id%20IN(2006,2007,2008)&outFields=measurements.*&offset=0&limit=5&f=csv
2. ?where=casgem_station_id%20IN(2006,2007,2008)&outFields=measurements.*&offset=5&limit=5&f=csv
3. ?where=casgem_station_id%20IN(2006,2007,2008)&outFields=measurements.*&offset=0&limit=10&f=csv

Appending 1 and 2 resulted exactly in 3.