### PR TITLE
DB-5191: Prevent unbounded related field queries

### DIFF
--- a/tablo/exceptions.py
+++ b/tablo/exceptions.py
@@ -1,0 +1,10 @@
+from django.core.exceptions import ValidationError
+from django.db.utils import DatabaseError
+
+
+class InvalidFieldsError(ValidationError, DatabaseError, ValueError):
+    """ A database field error caught before execution: extends ValueError for backwards compatibility. """
+
+
+class SQLInjectionError(ValidationError, DatabaseError):
+    """ A database error that should be caught before execution """

--- a/tablo/exceptions.py
+++ b/tablo/exceptions.py
@@ -1,10 +1,17 @@
 from django.core.exceptions import ValidationError
-from django.db.utils import DatabaseError
 
 
-class InvalidFieldsError(ValidationError, DatabaseError, ValueError):
+class InvalidSQLError(ValidationError):
+    """ A database error that should be caught before execution """
+
+
+class InvalidFieldsError(ValidationError, ValueError):
     """ A database field error caught before execution: extends ValueError for backwards compatibility. """
 
+    def __init__(self, message, fields=None, **kwargs):
+        super(InvalidFieldsError, self).__init__(message, **kwargs)
+        self.fields = fields if fields is not None else []
 
-class SQLInjectionError(ValidationError, DatabaseError):
-    """ A database error that should be caught before execution """
+
+class RelatedFieldsError(InvalidFieldsError):
+    """ A database field error caught before execution: raised when fields from related tables are invalid. """

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -5,7 +5,6 @@ import logging
 import time
 import re
 
-
 from django.db.utils import DatabaseError
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotAllowed

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -272,9 +272,9 @@ class QueryView(FeatureLayerView):
             # Query with limit plus one to determine if the limit excluded any features
             query_response = self.feature_service_layer.perform_query(limit, offset, **search_params)
         except ValidationError as ex:
+            # Failed validation of provided fields and incoming SQL are handled here
             return HttpResponseBadRequest(json.dumps({'error': ex.message}))
         except DatabaseError:
-            # Any generic database error, or failed validation of SQL injection
             return HttpResponseBadRequest(json.dumps({'error': 'Invalid request'}))
 
         exceeded_limit = query_response.pop('exceeded_limit')

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -406,7 +406,7 @@ def convert_wkt_to_esri_feature(response_items, for_layer):
         r.related_title: {
             'source': r.source_column,
             'target': r.target_column,
-            'fields': {f['name'] for f in r.fields if f['alias'] in query_fields}
+            'fields': {f['name'] for f in r.fields if f['aliased'] in query_fields}
         } for r in for_layer.relations
     }
     joined_tables = {k: v for k, v in joined_tables.items() if v['fields']}

--- a/tablo/interfaces/arcgis/views.py
+++ b/tablo/interfaces/arcgis/views.py
@@ -305,7 +305,7 @@ class QueryView(FeatureLayerView):
                 data['objectIdFieldName'] = object_id_field
                 data['objectIds'] = [feature[object_id_field] for feature in query_response]
             else:
-                queried = set(query_response[0].keys())
+                queried = set(query_response[0].keys()) if query_response else set()
                 features = convert_wkt_to_esri_feature(query_response, self.feature_service_layer)
                 data.update({
                     'count': len(features),

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -449,7 +449,10 @@ class FeatureServiceLayer(models.Model):
     def _validate_where_clause(self, where):
 
         parsed = self._parse_where_clause(where)
-        if parsed is not None and parsed[1]:
+
+        if parsed is None:
+            return
+        elif parsed[1]:
             raise SQLInjectionError('Invalid where clause')
 
         self._validate_fields(parsed[0])

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -547,16 +547,18 @@ class FeatureServiceLayer(models.Model):
 
         sql_statement = """
             SELECT all_data.{field}
-            FROM (
-                SELECT ROW_NUMBER() OVER (ORDER BY {field}) AS row_number, {field}
-                FROM {table}
-                WHERE {field} IS NOT NULL
-                ORDER BY {field}
-            ) all_data, (
-                SELECT ROUND((COUNT(0) / {break_count}), 0) AS how_many
-                FROM {table} serviceTable
-                WHERE serviceTable.{field} IS NOT NULL
-            ) count_table
+            FROM
+                (
+                    SELECT ROW_NUMBER() OVER (ORDER BY {field}) AS row_number, {field}
+                    FROM {table}
+                    WHERE {field} IS NOT NULL
+                    ORDER BY {field}
+                ) all_data,
+                (
+                    SELECT ROUND((COUNT(0) / {break_count}), 0) AS how_many
+                    FROM {table} serviceTable
+                    WHERE serviceTable.{field} IS NOT NULL
+                ) count_table
             WHERE MOD(row_number, how_many) = 0
             ORDER BY all_data.{field}
         """.format(field=field, table=self.table, break_count=break_count)

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -13,7 +13,7 @@ from django.db.models import signals
 from django.utils.datastructures import OrderedSet
 from sqlparse.tokens import Token
 
-from tablo.exceptions import InvalidFieldsError, RelatedFieldsError, InvalidSQLError
+from tablo.exceptions import InvalidFieldsError, InvalidSQLError, RelatedFieldsError
 from tablo.geom_utils import Extent, SpatialReference
 from tablo.utils import get_jenks_breaks, dictfetchall
 
@@ -557,7 +557,7 @@ class FeatureServiceLayer(models.Model):
                 FROM {table} serviceTable
                 WHERE serviceTable.{field} IS NOT NULL
             ) count_table
-            WHERE MOD(row_number,how_many) = 0
+            WHERE MOD(row_number, how_many) = 0
             ORDER BY all_data.{field}
         """.format(field=field, table=self.table, break_count=break_count)
 
@@ -600,9 +600,8 @@ class FeatureServiceLayer(models.Model):
                 WHERE {field} IS NOT NULL
             ) count_table
             WHERE service_table.{primary_key} = all_data.{primary_key} AND (
-                MOD(row_number,how_many) = 0 OR
-                row_number = 1 OR
-                row_number = total
+                MOD(row_number, how_many) = 0 OR
+                row_number IN (1, total)
             )
             ORDER BY service_table.{field}
         """.format(field=field, primary_key=self.object_id_field, table=self.table, num_samples=1000)

--- a/tablo/models.py
+++ b/tablo/models.py
@@ -215,7 +215,7 @@ class FeatureServiceLayer(models.Model):
 
             self._related_fields = OrderedDict()
             for field in (f for r in self.relations for f in r.fields):
-                field_key = field['alias']  # Will be related_title.field
+                field_key = field['aliased']  # Will be related_title.field
                 self.related_fields[field_key] = field
 
         return self._related_fields
@@ -297,7 +297,7 @@ class FeatureServiceLayer(models.Model):
         return {'data': queried_data, 'exceeded_limit': limited_data}
 
     def _alias_fields(self, fields):
-        """ Delimit and alias fields for query in double quotes, but ignore '*' """
+        """ Prepend table alias to fields, delimiting them in double quotes, but ignore '*' """
 
         if not fields:
             return self._expand_fields('*', True)
@@ -764,7 +764,7 @@ class FeatureServiceLayerRelations(models.Model):
 
             fields = get_fields(self.table)
             for field in fields:
-                field['alias'] = '{0}.{1}'.format(self.related_title, field['name'])
+                field['aliased'] = '{0}.{1}'.format(self.related_title, field['name'])
             self._fields = fields
 
         return self._fields


### PR DESCRIPTION
In this PR I made changes that:

1. Fix query error handling and validation: new exception types, better messages
2. Improve argument parsing in `perform_query` -- more robust now
3. Only allow related fields in `SELECT` and `ORDER BY` when `objectIds` have been provided
4. Improve limit/offset: moved enforcement and validation to the model
5. Ensure limit/offset doesn't clash with queries bounded by `objectIds` 
6. Change the default limit in `QueryView` back to 1000 (only applies to source table queries)
7. Remove the `total` parameter from the `QueryView` response
8. Ensure related field definitions are provided only when related data was selected

I ran `model_tests` afterward successfully, as well as did my own manual testing. I plan to do more testing on Monday: I will make sure the URL-based testing I had done previously still works, and adapt them to test query parameters in more combinations.