### PR TITLE
DB-5472: CSV: Aggregate field type not being validated

### DIFF
--- a/tablo/api.py
+++ b/tablo/api.py
@@ -475,9 +475,6 @@ class TemporaryFileResource(ModelResource):
 
             populate_point_data(dataset_id, csv_info)
             obj.delete()    # Temporary file has been moved to database, safe to delete
-        except InternalError as e:
-            logger.exception(e)
-            raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))
         except Exception as e:
             logger.exception(e)
             raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))

--- a/tablo/api.py
+++ b/tablo/api.py
@@ -362,7 +362,7 @@ class TemporaryFileResource(ModelResource):
 
                 {
                     "fieldNames": ["field one", "field two", "latitude", "longitude"],
-                    "dataTypes": ["STRING", "INTEGER", "DOUBLE", "DOUBLE"],
+                    "dataTypes": ["String", "Integer", "Double", "Double"],
                     "optionalFields": ["field one"],
                     "xColumn": "longitude",
                     "yColumn": "latitude",

--- a/tablo/api.py
+++ b/tablo/api.py
@@ -462,7 +462,7 @@ class TemporaryFileResource(ModelResource):
             # Use separate iterator of table rows to not exaust the main one
             optional_fields = determine_optional_fields(prepare_csv_rows(obj.file))
 
-            row_set = prepare_csv_rows(obj.file)
+            row_set = prepare_csv_rows(obj.file, csv_info)
             sample_row = next(row_set.sample)
             table_name = create_database_table(sample_row, dataset_id, optional_fields=optional_fields)
             populate_data(table_name, row_set)
@@ -476,6 +476,9 @@ class TemporaryFileResource(ModelResource):
             populate_point_data(dataset_id, csv_info)
             obj.delete()    # Temporary file has been moved to database, safe to delete
         except InternalError as e:
+            logger.exception(e)
+            raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))
+        except Exception as e:
             logger.exception(e)
             raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))
 

--- a/tablo/csv_utils.py
+++ b/tablo/csv_utils.py
@@ -44,7 +44,7 @@ def prepare_csv_rows(csv_file, csv_info=None):
 
     if csv_info:
         # If we have csv_info, then we know the column types, no need to guess
-        types = apply_csv_types(row_set.sample, csv_info)
+        types = types_from_config(row_set.sample, csv_info)
     else:
         types = type_guess(row_set.sample, strict=True)
 
@@ -53,7 +53,7 @@ def prepare_csv_rows(csv_file, csv_info=None):
     return row_set
 
 
-def apply_csv_types(rows, csv_info):
+def types_from_config(rows, csv_info):
     """
     Determines the type of the columns based on the csvInfo.dataTypes. This allows us to keep from guessing
     when the sender of the file knows more about the types than we do.

--- a/tablo/csv_utils.py
+++ b/tablo/csv_utils.py
@@ -1,8 +1,11 @@
 import re
 
-from messytables import CSVTableSet, headers_guess, offset_processor, types_processor, type_guess
+from collections import defaultdict
+from messytables import CSVTableSet, headers_guess, offset_processor, types_processor
 from messytables import StringType, DecimalType, IntegerType, DateType, Cell
+from messytables.compat23 import unicode_string
 from messytables.dateparser import create_date_formats
+from messytables.types import CellType
 
 from itertools import zip_longest
 
@@ -27,7 +30,8 @@ X_AND_Y_FIELDS = (
     ('x_', 'y_')
 )
 
-def prepare_csv_rows(csv_file):
+
+def prepare_csv_rows(csv_file, csv_info=None):
     row_set = CSVTableSet(csv_file).tables[0]
 
     offset, headers = headers_guess(row_set.sample)
@@ -38,13 +42,35 @@ def prepare_csv_rows(csv_file):
 
     DateType.formats = create_date_formats(day_first=False)
 
-    # We are never wanting boolean types, so remove that from the default list
-    eligible_types = [StringType, DecimalType, IntegerType, DateType]
-    types = type_guess(row_set.sample, types=eligible_types, strict=True)
+    if csv_info:
+        # If we have csv_info, then we know the column types, no need to guess
+        types = apply_csv_types(row_set.sample, csv_info)
+    else:
+        types = type_guess(row_set.sample, strict=True)
 
     row_set.register_processor(types_processor(types))
 
     return row_set
+
+
+def apply_csv_types(rows, csv_info):
+    """
+    Determines the type of the columns based on the csvInfo.dataTypes. This allows us to keep from guessing
+    when the sender of the file knows more about the types than we do.
+    """
+    columns = []
+    convert_type = {
+        'integer': IntegerType,
+        'string': StringType,
+        'decimal': DecimalType,
+        'date': DateType,
+        'empty': StringType  # Sender doesn't know type either, default to String
+    }
+    for row in rows:
+        for cell in row:
+            name_index = csv_info['fieldNames'].index(cell.column.lower())
+            columns.append(convert_type[csv_info['dataTypes'][name_index].lower()]())
+    return columns
 
 
 def convert_header_to_column_name(header):
@@ -83,6 +109,7 @@ def determine_x_and_y_fields(row):
 
     return x_field, y_field
 
+
 def headers_processor_remove_blank(headers):
     """ Removes any blank columns from the CSV file. Essentially, if the header is blank, don't add the column
         value. This prevents issues with blank columns in XLS and XLSX files."""
@@ -98,3 +125,88 @@ def headers_processor_remove_blank(headers):
                 _row.append(cell)
         return _row
     return apply_headers
+
+
+class EmptyType(CellType):
+    """ An empty cell """
+    result_type = unicode_string
+    guessing_weight = 0
+
+    def cast(self, value):
+        if value is None:
+            return None
+        if isinstance(value, self.result_type):
+            return value
+        try:
+            return unicode_string(value)
+        except UnicodeEncodeError:
+            return str(value)
+
+# We are never wanting boolean types, so remove that from the default list
+TYPES = [EmptyType, StringType, DecimalType, IntegerType, DateType]
+
+
+def type_guess(rows, types=TYPES, strict=False):
+    """
+    This is a modified version of the messyTables type_guess function. The modified version uses the EmptyType 
+    to signify that the field itself is empty. This allows us to differentitate between a field that had some String
+    values and a field that had no values.
+    
+    The type guesser aggregates the number of successful conversions of each column to each type, weights them by a
+    fixed type priority and select the most probable type for each column based on that figure. It returns a list of
+    ``CellType``. Empty cells are ignored.
+
+    Strict means that a type will not be guessed if parsing fails for a single cell in the column.
+    """
+
+    guesses = []
+    type_instances = [i for t in types for i in t.instances()]
+    if strict:
+        at_least_one_value = []
+        for ri, row in enumerate(rows):
+            diff = len(row) - len(guesses)
+            for _ in range(diff):
+                typesdict = {}
+                for type in type_instances:
+                    typesdict[type] = 0
+                guesses.append(typesdict)
+                at_least_one_value.append(False)
+            for ci, cell in enumerate(row):
+                if not cell.value:
+                    continue
+                at_least_one_value[ci] = True
+                for type in list(guesses[ci].keys()):
+                    if not type.test(cell.value):
+                        guesses[ci].pop(type)
+        # no need to set guessing weights before this
+        # because we only accept a type if it never fails
+        for i, guess in enumerate(guesses):
+            for type in guess:
+                guesses[i][type] = type.guessing_weight
+        # in case there were no values at all in the column,
+        # we set the guessed type to empty
+        for i, v in enumerate(at_least_one_value):
+            if not v:
+                guesses[i] = {EmptyType(): 0}
+    else:
+        for i, row in enumerate(rows):
+            diff = len(row) - len(guesses)
+            for _ in range(diff):
+                guesses.append(defaultdict(int))
+            for i, cell in enumerate(row):
+                # add empty guess so that we have at least one guess
+                guesses[i][EmptyType()] = guesses[i].get(EmptyType(), 0)
+                if not cell.value:
+                    continue
+                for type in type_instances:
+                    if type.test(cell.value):
+                        guesses[i][type] += type.guessing_weight
+    _columns = []
+    for guess in guesses:
+        # this first creates an array of tuples because we want the types to be
+        # sorted. Even though it is not specified, python chooses the first
+        # element in case of a tie
+        # See: http://stackoverflow.com/a/6783101/214950
+        guesses_tuples = [(t, guess[t]) for t in type_instances if t in guess]
+        _columns.append(max(guesses_tuples, key=lambda t_n: t_n[1])[0])
+    return _columns

--- a/tablo/tests/test_csv_utils.py
+++ b/tablo/tests/test_csv_utils.py
@@ -1,0 +1,67 @@
+from io import BytesIO
+from django.test import TestCase
+from messytables import StringType, IntegerType, DecimalType
+
+from tablo.csv_utils import prepare_csv_rows, EmptyType, convert_header_to_column_name, determine_x_and_y_fields
+
+
+class TestCSVUtils(TestCase):
+
+    def test_prepare_csv_rows(self):
+        test_csv_file = BytesIO(
+            b'header_one,header_two,header_three,header_four\n'
+            b'one,1,,1\n'
+            b'two,2,,2.1\n'
+        )
+        row_set = prepare_csv_rows(test_csv_file)
+        first_row = list(row_set.sample)[0]
+        self.assertEqual(first_row[0].type, StringType())
+        self.assertEqual(first_row[1].type, IntegerType())
+        self.assertEqual(first_row[2].type, EmptyType())
+        self.assertEqual(first_row[3].type, DecimalType())
+
+    def test_prepare_csv_rows_with_config(self):
+        # Specifies String for the Empty Type
+        csv_info = {
+            'fieldNames': ['header_one', 'header_two', 'header_three', 'header_four'],
+            'dataTypes': ['String', 'Integer', 'String', 'Decimal']
+        }
+        test_csv_file = BytesIO(
+            b'header_one,header_two,header_three,header_four\n'
+            b'one,1,,1\n'
+            b'two,2,,2.1\n'
+        )
+        row_set = prepare_csv_rows(test_csv_file, csv_info)
+        first_row = list(row_set.sample)[0]
+        self.assertEqual(first_row[0].type, StringType())
+        self.assertEqual(first_row[1].type, IntegerType())
+        self.assertEqual(first_row[2].type, StringType())
+        self.assertEqual(first_row[3].type, DecimalType())
+
+    def test_convert_header_to_column_name(self):
+        test_cases = [
+            ('header', 'header'),
+            ('my header', 'my_header'),
+            ('1_field', 'f_1_field'),
+            ('freeze', 'freeze_a')
+        ]
+
+        for test in test_cases:
+            self.assertEqual(convert_header_to_column_name(test[0]), test[1])
+
+    def test_determine_x_and_y_fields(self):
+        test_csv_file = BytesIO(
+            b'lon,lat\n'
+            b'123.4,50.2\n'
+        )
+        row_set = prepare_csv_rows(test_csv_file)
+        first_row = list(row_set.sample)[0]
+        self.assertEqual(determine_x_and_y_fields(first_row), ('lon', 'lat'))
+
+        test_csv_file = BytesIO(
+            b'lon,something_else\n'
+            b'123.4,50.2\n'
+        )
+        row_set = prepare_csv_rows(test_csv_file)
+        first_row = list(row_set.sample)[0]
+        self.assertEqual(determine_x_and_y_fields(first_row), (None, None))


### PR DESCRIPTION
Adds support for the Empty field type and also allows for sending in
the csv_info object to override any guesses made by the CSV parser.