### PR TITLE
Db 5039 - Error reporting from Tablo is incorrect

### DIFF
--- a/tablo/api.py
+++ b/tablo/api.py
@@ -477,20 +477,7 @@ class TemporaryFileResource(ModelResource):
             obj.delete()    # Temporary file has been moved to database, safe to delete
         except Exception as e:
             logger.exception(e)
-            error_msg = ''
-            if hasattr(e, 'message'):
-                error_msg = e.message
-            else:
-                error_msg = str(e)
-
-            print(error_msg)
-            error_code = 'UNKNOWN_ERROR'
-            if 'column' in error_msg and 'specified more than once' in error_msg:
-                error_code = 'DUPLICATE_COLUMN'
-            elif 'transform' in err_msg:
-                error_code = 'TRANSFORM'
-
-            raise ImmediateHttpResponse(HttpBadRequest(error_code))
+            raise ImmediateHttpResponse(HttpBadRequest(self.get_except_error_code(e)))
 
         return self.create_response(request, bundle)
 
@@ -520,9 +507,24 @@ class TemporaryFileResource(ModelResource):
             obj.delete()    # Temporary file has been moved to database, safe to delete
         except InternalError as e:
             logger.exception(e)
-            raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))
+            raise ImmediateHttpResponse(HttpBadRequest(self.get_except_error_code(e)))
 
         return self.create_response(request, bundle)
+
+    def get_except_error_code(self, e):
+        error_msg = ''
+        if hasattr(e, 'message'):
+            error_msg = e.message
+        else:
+            error_msg = str(e)
+
+        error_code = 'UNKNOWN_ERROR'
+        if 'column' in error_msg and 'specified more than once' in error_msg:
+            error_code = 'DUPLICATE_COLUMN'
+        elif 'transform' in err_msg:
+            error_code = 'TRANSFORM'
+
+        return error_code
 
 
 def json_date_serializer(obj):

--- a/tablo/api.py
+++ b/tablo/api.py
@@ -477,7 +477,20 @@ class TemporaryFileResource(ModelResource):
             obj.delete()    # Temporary file has been moved to database, safe to delete
         except Exception as e:
             logger.exception(e)
-            raise ImmediateHttpResponse(HttpBadRequest('Error deploying file to database.'))
+            error_msg = ''
+            if hasattr(e, 'message'):
+                error_msg = e.message
+            else:
+                error_msg = str(e)
+
+            print(error_msg)
+            error_code = 'UNKNOWN_ERROR'
+            if 'column' in error_msg and 'specified more than once' in error_msg:
+                error_code = 'DUPLICATE_COLUMN'
+            elif 'transform' in err_msg:
+                error_code = 'TRANSFORM'
+
+            raise ImmediateHttpResponse(HttpBadRequest(error_code))
 
         return self.create_response(request, bundle)
 

--- a/tablo/api.py
+++ b/tablo/api.py
@@ -505,7 +505,7 @@ class TemporaryFileResource(ModelResource):
 
             populate_point_data(dataset_id, csv_info)
             obj.delete()    # Temporary file has been moved to database, safe to delete
-        except InternalError as e:
+        except Exception as e:
             logger.exception(e)
             raise ImmediateHttpResponse(HttpBadRequest(self.get_except_error_code(e)))
 

--- a/tablo/api.py
+++ b/tablo/api.py
@@ -521,7 +521,7 @@ class TemporaryFileResource(ModelResource):
         error_code = 'UNKNOWN_ERROR'
         if 'column' in error_msg and 'specified more than once' in error_msg:
             error_code = 'DUPLICATE_COLUMN'
-        elif 'transform' in err_msg:
+        elif 'transform' in error_msg:
             error_code = 'TRANSFORM'
 
         return error_code


### PR DESCRIPTION
Note:  This PR is a matching set for one in databasin_web. 

Fixed to no longer issue "could not transform points" error when importing csv with duplicate column names. Can add more specific errors as we figure out what those are. Added code in tablo to the append method as well to report errors when the dataset is edited, however could not actually produce any errors at all!

Errors:

Transform points error - Create a csv spreadsheet with bad lat/long values:
River Name,Entry Id,Longitude,Latitude,Team,Temperature,Author,Date,Is Celsius
Columbia 'D' River,4,9999.5555,45.2266,Team A,55,John Doe,01/11/2016,1

Duplicate columns error - Create a csv spreadsheet with a duplicate column:
River Name,Entry Id,Longitude,Latitude,Team,Temperature,Author,Date,Is Celsius,Is Celsius
Columbia 'D' River,4,-122.5555,45.2266,Team A,55,John Doe,01/11/2016,1,1