### PR TITLE
DB-5705  Add test for tablo error messages

### DIFF
--- a/tablo/api.py
+++ b/tablo/api.py
@@ -511,6 +511,7 @@ class TemporaryFileResource(ModelResource):
 
         return self.create_response(request, bundle)
 
+
 def json_date_serializer(obj):
     # Handles date serialization when part of the response object
 

--- a/tablo/tests/test_utils.py
+++ b/tablo/tests/test_utils.py
@@ -1,0 +1,27 @@
+
+from django.test import TestCase
+
+from django.db.utils import InternalError
+
+from tablo.utils import get_file_ops_error_code
+
+class PerformUtilsTestCase(TestCase):
+
+    def test_get_file_ops_error_code(self):
+        error_except = InternalError(
+            'transform: couldn\'t project point (4.0869e+10 4.53884e+11 0): latitude or longitude exceeded limits (-14)'
+        )
+        error_code = get_file_ops_error_code(error_except)
+        self.assertEqual(error_code, 'TRANSFORM')
+
+        error_except = InternalError(
+            'column "is_celsius" specified more than once'
+        )
+        error_code = get_file_ops_error_code(error_except)
+        self.assertEqual(error_code, 'DUPLICATE_COLUMN')
+
+        error_except = InternalError(
+            'some random error'
+        )
+        error_code = get_file_ops_error_code(error_except)
+        self.assertEqual(error_code, 'UNKNOWN_ERROR')

--- a/tablo/utils.py
+++ b/tablo/utils.py
@@ -110,6 +110,22 @@ def json_date_serializer(obj):
     return json.JSONEncoder.default(obj)
 
 
+def get_file_ops_error_code(e):
+    error_msg = ''
+    if hasattr(e, 'message'):
+        error_msg = e.message
+    else:
+        error_msg = str(e)
+
+    error_code = 'UNKNOWN_ERROR'
+    if 'column' in error_msg and 'specified more than once' in error_msg:
+        error_code = 'DUPLICATE_COLUMN'
+    elif 'transform' in error_msg:
+        error_code = 'TRANSFORM'
+
+    return error_code
+
+
 class JSONField(CharField):
     def convert(self, value):
         if value is None:


### PR DESCRIPTION
I restructured api.py a bit, renaming the method get_except_error_code to get_file_ops_error_code, and moving it to utils.py.
Then I added the test_utils.py file containing the test_get_file_ops_error_code.